### PR TITLE
Do not allow other users to edit or delete my posts

### DIFF
--- a/lib/finsta_web/live/post_live/index.ex
+++ b/lib/finsta_web/live/post_live/index.ex
@@ -29,9 +29,17 @@ defmodule FinstaWeb.PostLive.Index do
   end
 
   defp apply_action(socket, :edit, %{"id" => id}) do
-    socket
-    |> assign(:page_title, "Edit Post")
-    |> assign(:post, Posts.get_post!(id))
+    post = Posts.get_post!(id)
+
+    if post.user_id == socket.assigns.current_user.id do
+      socket
+      |> assign(:page_title, "Edit Post")
+      |> assign(:post, post)
+    else
+      socket
+      |> put_flash(:error, "You are not authorized to edit this post")
+      |> redirect(to: ~p"/posts")
+    end
   end
 
   defp apply_action(socket, :new, _params) do
@@ -66,8 +74,15 @@ defmodule FinstaWeb.PostLive.Index do
   @impl true
   def handle_event("delete", %{"id" => id}, socket) do
     post = Posts.get_post!(id)
-    {:ok, _} = Posts.delete_post(post)
 
-    {:noreply, stream_delete(socket, :posts, post)}
+    if post.user_id == socket.assigns.current_user.id do
+      {:ok, _} = Posts.delete_post(post)
+
+      {:noreply, stream_delete(socket, :posts, post)}
+    else
+      socket
+      |> put_flash(:error, "You are not authorized to delete this post")
+      |> redirect(to: ~p"/posts")
+    end
   end
 end

--- a/lib/finsta_web/live/post_live/index.html.heex
+++ b/lib/finsta_web/live/post_live/index.html.heex
@@ -18,10 +18,11 @@
     <div class="sr-only">
       <.link navigate={~p"/posts/#{post}"}>Show</.link>
     </div>
-    <.link patch={~p"/posts/#{post}/edit"}>Edit</.link>
+    <.link :if={@current_user.id == post.user_id} patch={~p"/posts/#{post}/edit"}>Edit</.link>
   </:action>
   <:action :let={{id, post}}>
     <.link
+      :if={@current_user.id == post.user_id}
       phx-click={JS.push("delete", value: %{id: post.id}) |> hide("##{id}")}
       data-confirm="Are you sure?"
     >


### PR DESCRIPTION
This PR hides the "edit" or "delete" buttons in posts that do not belong to the current user.
And checks ownership before editing or deleting a post (in case a malicious user manages to manually get there).

This was something we spotted with @jdelmazo9 and @rmatteoda while reviewing a PR together the other day

