### PR TITLE
Move user belongs to post condition to context

### DIFF
--- a/lib/finsta/posts.ex
+++ b/lib/finsta/posts.ex
@@ -38,6 +38,23 @@ defmodule Finsta.Posts do
   def get_post!(id), do: Repo.get!(Post, id) |> Repo.preload([:likes])
 
   @doc """
+  Gets a single post that belongs to a user.
+
+  Raises `Ecto.NoResultsError` if the Post does not exist for that user.
+
+  ## Examples
+
+      iex> get_user_post!(user, 987)
+      %Post{}
+
+      iex> get_user_post!(user, 789)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_user_post!(user, post_id),
+    do: Repo.get_by!(Post, id: post_id, user_id: user.id)
+
+  @doc """
   Creates a post.
 
   ## Examples
@@ -62,22 +79,18 @@ defmodule Finsta.Posts do
 
   ## Examples
 
-      iex> update_post(user, post, %{field: new_value})
+      iex> update_post(post, %{field: new_value})
       {:ok, %Post{}}
 
-      iex> update_post(user, post, %{field: bad_value})
+      iex> update_post(post, %{field: bad_value})
       {:error, %Ecto.Changeset{}}
 
   """
-  def update_post(user, %Post{} = post, attrs) do
-    if post.user_id == user.id do
-      post
-      |> Post.changeset(attrs)
-      |> Repo.update()
-      |> tap(&broadcast_post(&1, :update))
-    else
-      {:error, :unauthorized}
-    end
+  def update_post(%Post{} = post, attrs) do
+    post
+    |> Post.changeset(attrs)
+    |> Repo.update()
+    |> tap(&broadcast_post(&1, :update))
   end
 
   @doc """
@@ -85,21 +98,17 @@ defmodule Finsta.Posts do
 
   ## Examples
 
-      iex> delete_post(user, post)
+      iex> delete_post(post)
       {:ok, %Post{}}
 
-      iex> delete_post(user, post)
+      iex> delete_post(post)
       {:error, %Ecto.Changeset{}}
 
   """
-  def delete_post(user, %Post{} = post) do
-    if post.user_id == user.id do
-      post
-      |> Repo.delete()
-      |> tap(&broadcast_post(&1, :delete))
-    else
-      {:error, :unauthorized}
-    end
+  def delete_post(%Post{} = post) do
+    post
+    |> Repo.delete()
+    |> tap(&broadcast_post(&1, :delete))
   end
 
   @doc """

--- a/lib/finsta/posts.ex
+++ b/lib/finsta/posts.ex
@@ -62,18 +62,22 @@ defmodule Finsta.Posts do
 
   ## Examples
 
-      iex> update_post(post, %{field: new_value})
+      iex> update_post(user, post, %{field: new_value})
       {:ok, %Post{}}
 
-      iex> update_post(post, %{field: bad_value})
+      iex> update_post(user, post, %{field: bad_value})
       {:error, %Ecto.Changeset{}}
 
   """
-  def update_post(%Post{} = post, attrs) do
-    post
-    |> Post.changeset(attrs)
-    |> Repo.update()
-    |> tap(&broadcast_post(&1, :update))
+  def update_post(user, %Post{} = post, attrs) do
+    if post.user_id == user.id do
+      post
+      |> Post.changeset(attrs)
+      |> Repo.update()
+      |> tap(&broadcast_post(&1, :update))
+    else
+      {:error, :unauthorized}
+    end
   end
 
   @doc """
@@ -81,17 +85,21 @@ defmodule Finsta.Posts do
 
   ## Examples
 
-      iex> delete_post(post)
+      iex> delete_post(user, post)
       {:ok, %Post{}}
 
-      iex> delete_post(post)
+      iex> delete_post(user, post)
       {:error, %Ecto.Changeset{}}
 
   """
-  def delete_post(%Post{} = post) do
-    post
-    |> Repo.delete()
-    |> tap(&broadcast_post(&1, :delete))
+  def delete_post(user, %Post{} = post) do
+    if post.user_id == user.id do
+      post
+      |> Repo.delete()
+      |> tap(&broadcast_post(&1, :delete))
+    else
+      {:error, :unauthorized}
+    end
   end
 
   @doc """

--- a/lib/finsta_web/live/post_live/form_component.ex
+++ b/lib/finsta_web/live/post_live/form_component.ex
@@ -68,12 +68,8 @@ defmodule FinstaWeb.PostLive.FormComponent do
     save_post(socket, socket.assigns.action, post_params)
   end
 
-  defp save_post(
-         %{assigns: %{current_user: current_user, post: post}} = socket,
-         :edit,
-         post_params
-       ) do
-    case Posts.update_post(current_user, post, post_params) do
+  defp save_post(socket, :edit, post_params) do
+    case Posts.update_post(socket.assigns.post, post_params) do
       {:ok, post} ->
         notify_parent({:saved, post})
 

--- a/lib/finsta_web/live/post_live/form_component.ex
+++ b/lib/finsta_web/live/post_live/form_component.ex
@@ -69,7 +69,7 @@ defmodule FinstaWeb.PostLive.FormComponent do
   end
 
   defp save_post(socket, :edit, post_params) do
-    case Posts.update_post(socket.assigns.post, post_params) do
+    case Posts.update_post(socket.assigns.current_user, socket.assigns.post, post_params) do
       {:ok, post} ->
         notify_parent({:saved, post})
 

--- a/lib/finsta_web/live/post_live/form_component.ex
+++ b/lib/finsta_web/live/post_live/form_component.ex
@@ -68,8 +68,12 @@ defmodule FinstaWeb.PostLive.FormComponent do
     save_post(socket, socket.assigns.action, post_params)
   end
 
-  defp save_post(socket, :edit, post_params) do
-    case Posts.update_post(socket.assigns.current_user, socket.assigns.post, post_params) do
+  defp save_post(
+         %{assigns: %{current_user: current_user, post: post}} = socket,
+         :edit,
+         post_params
+       ) do
+    case Posts.update_post(current_user, post, post_params) do
       {:ok, post} ->
         notify_parent({:saved, post})
 

--- a/lib/finsta_web/live/post_live/index.ex
+++ b/lib/finsta_web/live/post_live/index.ex
@@ -29,7 +29,7 @@ defmodule FinstaWeb.PostLive.Index do
   end
 
   defp apply_action(socket, :edit, %{"id" => id}) do
-    post = Posts.get_post!(id)
+    post = Posts.get_user_post!(socket.assigns.current_user, id)
 
     socket
     |> assign(:page_title, "Edit Post")
@@ -67,8 +67,8 @@ defmodule FinstaWeb.PostLive.Index do
 
   @impl true
   def handle_event("delete", %{"id" => id}, socket) do
-    post = Posts.get_post!(id)
-    {:ok, _} = Posts.delete_post(socket.assigns.current_user, post)
+    post = Posts.get_user_post!(socket.assigns.current_user, id)
+    {:ok, _} = Posts.delete_post(post)
 
     {:noreply, stream_delete(socket, :posts, post)}
   end

--- a/lib/finsta_web/live/post_live/index.ex
+++ b/lib/finsta_web/live/post_live/index.ex
@@ -31,15 +31,9 @@ defmodule FinstaWeb.PostLive.Index do
   defp apply_action(socket, :edit, %{"id" => id}) do
     post = Posts.get_post!(id)
 
-    if post.user_id == socket.assigns.current_user.id do
-      socket
-      |> assign(:page_title, "Edit Post")
-      |> assign(:post, post)
-    else
-      socket
-      |> put_flash(:error, "You are not authorized to edit this post")
-      |> redirect(to: ~p"/posts")
-    end
+    socket
+    |> assign(:page_title, "Edit Post")
+    |> assign(:post, post)
   end
 
   defp apply_action(socket, :new, _params) do
@@ -74,16 +68,9 @@ defmodule FinstaWeb.PostLive.Index do
   @impl true
   def handle_event("delete", %{"id" => id}, socket) do
     post = Posts.get_post!(id)
+    {:ok, _} = Posts.delete_post(socket.assigns.current_user, post)
 
-    if post.user_id == socket.assigns.current_user.id do
-      {:ok, _} = Posts.delete_post(post)
-
-      {:noreply, stream_delete(socket, :posts, post)}
-    else
-      socket
-      |> put_flash(:error, "You are not authorized to delete this post")
-      |> redirect(to: ~p"/posts")
-    end
+    {:noreply, stream_delete(socket, :posts, post)}
   end
 
   @impl true

--- a/lib/finsta_web/live/post_live/show.html.heex
+++ b/lib/finsta_web/live/post_live/show.html.heex
@@ -2,7 +2,11 @@
   Post <%= @post.id %>
   <:subtitle>This is a post record from your database.</:subtitle>
   <:actions>
-    <.link patch={~p"/posts/#{@post}/show/edit"} phx-click={JS.push_focus()}>
+    <.link
+      :if={@current_user.id == @post.user_id}
+      patch={~p"/posts/#{@post}/show/edit"}
+      phx-click={JS.push_focus()}
+    >
       <.button>Edit post</.button>
     </.link>
   </:actions>
@@ -23,6 +27,7 @@
     title={@page_title}
     action={@live_action}
     post={@post}
+    current_user={@current_user}
     patch={~p"/posts/#{@post}"}
   />
 </.modal>

--- a/test/finsta/posts_test.exs
+++ b/test/finsta/posts_test.exs
@@ -4,6 +4,7 @@ defmodule Finsta.PostsTest do
   alias Finsta.Posts
 
   import Finsta.AccountsFixtures
+  import Finsta.AccountsFixtures
 
   describe "posts" do
     alias Finsta.Posts.Post
@@ -28,6 +29,23 @@ defmodule Finsta.PostsTest do
       assert result.user_id == post.user_id
     end
 
+    test "get_user_post!/2 returns the post with given id if the post belongs to the user" do
+      user = user_fixture()
+      post = post_with_user_fixture(user)
+
+      result = Posts.get_user_post!(user, post.id)
+
+      assert result.caption == post.caption
+      assert result.user_id == post.user_id
+    end
+
+    test "get_user_post!/2 raises NoResultError when the post with given id doesn't belong to the user " do
+      user = user_fixture()
+      post = post_fixture()
+
+      assert_raise Ecto.NoResultsError, fn -> Posts.get_user_post!(user, post.id) end
+    end
+
     test "create_post/1 with valid data creates a post" do
       user = user_fixture()
       valid_attrs = %{caption: "some caption", image_url: "image.png"}
@@ -44,45 +62,26 @@ defmodule Finsta.PostsTest do
       assert {:error, %Ecto.Changeset{}} = Posts.create_post(user, @invalid_attrs)
     end
 
-    test "update_post/3 with valid data updates the post when it belongs to the user" do
-      user = user_fixture()
-      post = post_fixture(%{}, user: user)
+    test "update_post/2 with valid data updates the post when it belongs to the user" do
+      post = post_fixture()
 
       update_attrs = %{caption: "some updated caption"}
 
-      assert {:ok, %Post{} = post} = Posts.update_post(user, post, update_attrs)
+      assert {:ok, %Post{} = post} = Posts.update_post(post, update_attrs)
       assert post.caption == "some updated caption"
     end
 
-    test "update_post/3 with valid data doesn't updates the post when it doesn't belong to the user" do
-      user = user_fixture()
-      post = post_fixture(%{})
-
-      update_attrs = %{caption: "some updated caption"}
-
-      assert {:error, :unauthorized} = Posts.update_post(user, post, update_attrs)
-    end
-
-    test "update_post/3 with invalid data returns error changeset" do
-      user = user_fixture()
-      post = post_fixture(%{}, user: user)
-
-      assert {:error, %Ecto.Changeset{}} = Posts.update_post(user, post, @invalid_attrs)
-    end
-
-    test "delete_post/2 deletes the post when it belongs to the user" do
-      user = user_fixture()
-      post = post_fixture(%{}, user: user)
-
-      assert {:ok, %Post{}} = Posts.delete_post(user, post)
-      assert_raise Ecto.NoResultsError, fn -> Posts.get_post!(post.id) end
-    end
-
-    test "delete_post/2 doesn't delete the post when it doesn't belong to the user" do
-      user = user_fixture()
+    test "update_post/2 with invalid data returns error changeset" do
       post = post_fixture()
 
-      assert {:error, :unauthorized} = Posts.delete_post(user, post)
+      assert {:error, %Ecto.Changeset{}} = Posts.update_post(post, @invalid_attrs)
+    end
+
+    test "delete_post/1 deletes the post" do
+      post = post_fixture()
+
+      assert {:ok, %Post{}} = Posts.delete_post(post)
+      assert_raise Ecto.NoResultsError, fn -> Posts.get_post!(post.id) end
     end
 
     test "change_post/1 returns a post changeset" do

--- a/test/finsta/posts_test.exs
+++ b/test/finsta/posts_test.exs
@@ -44,23 +44,45 @@ defmodule Finsta.PostsTest do
       assert {:error, %Ecto.Changeset{}} = Posts.create_post(user, @invalid_attrs)
     end
 
-    test "update_post/2 with valid data updates the post" do
-      post = post_fixture()
+    test "update_post/3 with valid data updates the post when it belongs to the user" do
+      user = user_fixture()
+      post = post_fixture(%{}, user: user)
+
       update_attrs = %{caption: "some updated caption"}
 
-      assert {:ok, %Post{} = post} = Posts.update_post(post, update_attrs)
+      assert {:ok, %Post{} = post} = Posts.update_post(user, post, update_attrs)
       assert post.caption == "some updated caption"
     end
 
-    test "update_post/2 with invalid data returns error changeset" do
-      post = post_fixture()
-      assert {:error, %Ecto.Changeset{}} = Posts.update_post(post, @invalid_attrs)
+    test "update_post/3 with valid data doesn't updates the post when it doesn't belong to the user" do
+      user = user_fixture()
+      post = post_fixture(%{})
+
+      update_attrs = %{caption: "some updated caption"}
+
+      assert {:error, :unauthorized} = Posts.update_post(user, post, update_attrs)
     end
 
-    test "delete_post/1 deletes the post" do
-      post = post_fixture()
-      assert {:ok, %Post{}} = Posts.delete_post(post)
+    test "update_post/3 with invalid data returns error changeset" do
+      user = user_fixture()
+      post = post_fixture(%{}, user: user)
+
+      assert {:error, %Ecto.Changeset{}} = Posts.update_post(user, post, @invalid_attrs)
+    end
+
+    test "delete_post/2 deletes the post when it belongs to the user" do
+      user = user_fixture()
+      post = post_fixture(%{}, user: user)
+
+      assert {:ok, %Post{}} = Posts.delete_post(user, post)
       assert_raise Ecto.NoResultsError, fn -> Posts.get_post!(post.id) end
+    end
+
+    test "delete_post/2 doesn't delete the post when it doesn't belong to the user" do
+      user = user_fixture()
+      post = post_fixture()
+
+      assert {:error, :unauthorized} = Posts.delete_post(user, post)
     end
 
     test "change_post/1 returns a post changeset" do

--- a/test/finsta/posts_test.exs
+++ b/test/finsta/posts_test.exs
@@ -4,7 +4,6 @@ defmodule Finsta.PostsTest do
   alias Finsta.Posts
 
   import Finsta.AccountsFixtures
-  import Finsta.AccountsFixtures
 
   describe "posts" do
     alias Finsta.Posts.Post
@@ -62,9 +61,8 @@ defmodule Finsta.PostsTest do
       assert {:error, %Ecto.Changeset{}} = Posts.create_post(user, @invalid_attrs)
     end
 
-    test "update_post/2 with valid data updates the post when it belongs to the user" do
+    test "update_post/2 with valid data updates the post" do
       post = post_fixture()
-
       update_attrs = %{caption: "some updated caption"}
 
       assert {:ok, %Post{} = post} = Posts.update_post(post, update_attrs)
@@ -73,13 +71,11 @@ defmodule Finsta.PostsTest do
 
     test "update_post/2 with invalid data returns error changeset" do
       post = post_fixture()
-
       assert {:error, %Ecto.Changeset{}} = Posts.update_post(post, @invalid_attrs)
     end
 
     test "delete_post/1 deletes the post" do
       post = post_fixture()
-
       assert {:ok, %Post{}} = Posts.delete_post(post)
       assert_raise Ecto.NoResultsError, fn -> Posts.get_post!(post.id) end
     end

--- a/test/finsta_web/live/post_live_test.exs
+++ b/test/finsta_web/live/post_live_test.exs
@@ -9,9 +9,8 @@ defmodule FinstaWeb.PostLiveTest do
   @update_attrs %{caption: "some updated caption"}
   @invalid_attrs %{caption: nil}
 
-  defp create_post(user \\ nil) do
-    post_with_user_fixture(user)
-  end
+  defp create_post(), do: post_fixture()
+  defp create_post(user), do: post_with_user_fixture(user)
 
   setup %{conn: conn} do
     logged_out_conn = conn

--- a/test/finsta_web/live/post_live_test.exs
+++ b/test/finsta_web/live/post_live_test.exs
@@ -10,7 +10,7 @@ defmodule FinstaWeb.PostLiveTest do
   @invalid_attrs %{caption: nil}
 
   defp create_post(user \\ nil) do
-    post_fixture(%{}, user: user)
+    post_with_user_fixture(user)
   end
 
   setup %{conn: conn} do
@@ -97,7 +97,7 @@ defmodule FinstaWeb.PostLiveTest do
       assert html =~ "some updated caption"
     end
 
-    test "can't update post in listing when post doesn't belong to user", %{conn: conn} do
+    test "doesn't show edit button in listing when post doesn't belong to the user", %{conn: conn} do
       post = create_post()
 
       {:ok, index_live, _html} = live(conn, ~p"/posts")
@@ -105,14 +105,16 @@ defmodule FinstaWeb.PostLiveTest do
       refute index_live |> has_element?("#posts-#{post.id} a", "Edit")
     end
 
-    test "deletes post in listing when post belongs to user", %{conn: conn, post: post} do
+    test "deletes post in listing when post belongs to the user", %{conn: conn, post: post} do
       {:ok, index_live, _html} = live(conn, ~p"/posts")
 
       assert index_live |> element("#posts-#{post.id} a", "Delete") |> render_click()
       refute has_element?(index_live, "#posts-#{post.id}")
     end
 
-    test "can't delete post in listing when post doesn't belong to user", %{conn: conn} do
+    test "doesn't show delete button in listing when post doesn't belong to the user", %{
+      conn: conn
+    } do
       post = create_post()
 
       {:ok, index_live, _html} = live(conn, ~p"/posts")
@@ -133,7 +135,7 @@ defmodule FinstaWeb.PostLiveTest do
       assert html =~ post.caption
     end
 
-    test "updates post within modal when post belongs to user", %{conn: conn, post: post} do
+    test "updates post within modal when post belongs to the user", %{conn: conn, post: post} do
       {:ok, show_live, _html} = live(conn, ~p"/posts/#{post}")
 
       assert show_live |> element("a", "Edit") |> render_click() =~
@@ -156,12 +158,20 @@ defmodule FinstaWeb.PostLiveTest do
       assert html =~ "some updated caption"
     end
 
-    test "can't update post within modal when post doesn't belong to user", %{conn: conn} do
+    test "doesn't show edit button when post doesn't belong to the user", %{conn: conn} do
       post = create_post()
 
       {:ok, show_live, _html} = live(conn, ~p"/posts/#{post}")
 
       refute show_live |> has_element?("a", "Edit")
+    end
+
+    test "returns 404 when visiting /edit route and post doesn't belong to the user", %{
+      conn: conn
+    } do
+      post = create_post()
+
+      assert_raise Ecto.NoResultsError, fn -> live(conn, ~p"/posts/#{post}/edit") end
     end
   end
 end

--- a/test/finsta_web/live/post_live_test.exs
+++ b/test/finsta_web/live/post_live_test.exs
@@ -133,7 +133,7 @@ defmodule FinstaWeb.PostLiveTest do
       assert html =~ post.caption
     end
 
-    test "updates post within modal", %{conn: conn, post: post} do
+    test "updates post within modal when post belongs to user", %{conn: conn, post: post} do
       {:ok, show_live, _html} = live(conn, ~p"/posts/#{post}")
 
       assert show_live |> element("a", "Edit") |> render_click() =~
@@ -154,6 +154,14 @@ defmodule FinstaWeb.PostLiveTest do
       html = render(show_live)
       assert html =~ "Post updated successfully"
       assert html =~ "some updated caption"
+    end
+
+    test "can't update post within modal when post doesn't belong to user", %{conn: conn} do
+      post = create_post()
+
+      {:ok, show_live, _html} = live(conn, ~p"/posts/#{post}")
+
+      refute show_live |> has_element?("a", "Edit")
     end
   end
 end

--- a/test/finsta_web/live/post_live_test.exs
+++ b/test/finsta_web/live/post_live_test.exs
@@ -9,8 +9,8 @@ defmodule FinstaWeb.PostLiveTest do
   @update_attrs %{caption: "some updated caption"}
   @invalid_attrs %{caption: nil}
 
-  defp create_post(user) do
-    post_fixture(%{user_id: user.id})
+  defp create_post(user \\ nil) do
+    post_fixture(%{}, user: user)
   end
 
   setup %{conn: conn} do
@@ -74,7 +74,7 @@ defmodule FinstaWeb.PostLiveTest do
       assert html =~ "some caption"
     end
 
-    test "updates post in listing", %{conn: conn, post: post} do
+    test "updates post in listing when post belongs to user", %{conn: conn, post: post} do
       {:ok, index_live, _html} = live(conn, ~p"/posts")
 
       assert index_live |> element("#posts-#{post.id} a", "Edit") |> render_click() =~
@@ -97,11 +97,27 @@ defmodule FinstaWeb.PostLiveTest do
       assert html =~ "some updated caption"
     end
 
-    test "deletes post in listing", %{conn: conn, post: post} do
+    test "can't update post in listing when post doesn't belong to user", %{conn: conn} do
+      post = create_post()
+
+      {:ok, index_live, _html} = live(conn, ~p"/posts")
+
+      refute index_live |> has_element?("#posts-#{post.id} a", "Edit")
+    end
+
+    test "deletes post in listing when post belongs to user", %{conn: conn, post: post} do
       {:ok, index_live, _html} = live(conn, ~p"/posts")
 
       assert index_live |> element("#posts-#{post.id} a", "Delete") |> render_click()
       refute has_element?(index_live, "#posts-#{post.id}")
+    end
+
+    test "can't delete post in listing when post doesn't belong to user", %{conn: conn} do
+      post = create_post()
+
+      {:ok, index_live, _html} = live(conn, ~p"/posts")
+
+      refute index_live |> has_element?("#posts-#{post.id} a", "Delete")
     end
   end
 

--- a/test/support/fixtures/posts_fixtures.ex
+++ b/test/support/fixtures/posts_fixtures.ex
@@ -9,8 +9,12 @@ defmodule Finsta.PostsFixtures do
   @doc """
   Generate a post.
   """
-  def post_fixture(attrs \\ %{}) do
-    user = user_fixture()
+  def post_fixture(attrs \\ %{}, opts \\ []) do
+    user =
+      case Keyword.get(opts, :user) do
+        nil -> user_fixture()
+        user -> user
+      end
 
     attrs =
       attrs

--- a/test/support/fixtures/posts_fixtures.ex
+++ b/test/support/fixtures/posts_fixtures.ex
@@ -9,13 +9,16 @@ defmodule Finsta.PostsFixtures do
   @doc """
   Generate a post.
   """
-  def post_fixture(attrs \\ %{}, opts \\ []) do
-    user =
-      case Keyword.get(opts, :user) do
-        nil -> user_fixture()
-        user -> user
-      end
+  def post_fixture(attrs \\ %{}) do
+    user = user_fixture()
+    create_post(user, attrs)
+  end
 
+  def post_with_user_fixture(user, attrs \\ %{}) do
+    create_post(user, attrs)
+  end
+
+  defp create_post(user, attrs) do
     attrs =
       attrs
       |> Enum.into(%{


### PR DESCRIPTION
Move user belongs to post condition to context

It also

- Disable the edit button on the show page when the post doesn't belong to the user
- Add test for presentation and context logic